### PR TITLE
临时解决QQ频道、KOOK异常

### DIFF
--- a/utils/face.js
+++ b/utils/face.js
@@ -468,12 +468,18 @@ export async function convertFaces (msg, handleAt = false, e) {
   handleAt = e?.isGroup && handleAt
   let groupMembers
   let groupCardQQMap = {}
-  if (handleAt && typeof e.group.getMemberMap === 'function') {
-    groupMembers = await e.group.getMemberMap()
-    for (let key of groupMembers.keys()) {
-      groupCardQQMap[groupMembers.get(key).card || groupMembers.get(key).nickname] = groupMembers.get(key).user_id
+  if (handleAt) {
+    try {
+      groupMembers = await e.group.getMemberMap()
+    } catch (err) {
+      console.error(`Failed to get group members: ${err}`)
     }
-  }
+    if (groupMembers) {
+      for (let key of groupMembers.keys()) {
+        groupCardQQMap[groupMembers.get(key).card || groupMembers.get(key).nickname] = groupMembers.get(key).user_id
+      }
+    }
+}
   let tmpMsg = ''
   let tmpFace = ''
   let tmpAt = ''


### PR DESCRIPTION
利用catch块隔离，临时解决获取不到e.group函数时自动跳过报错并继续执行