### PR TITLE
fix: waitForTimeout is not a function

### DIFF
--- a/utils/common.js
+++ b/utils/common.js
@@ -353,14 +353,11 @@ export async function renderUrl (e, url, renderCfg = {}) {
   const page = await _puppeteer.browser.newPage()
   let base64
   try {
-    await page.goto(url, { timeout: 120000 })
+    await page.goto(url, { timeout: 120000 , waitUntil: 'networkidle0' })
     await page.setViewport(renderCfg.Viewport || {
       width: 1280,
       height: 720
     })
-    const sleep = ms => new Promise(res => setTimeout(res, ms));
-    /** 等待1秒 */
-    await sleep(1000);
     let buff = base64 = await page.screenshot({ fullPage: true })
     base64 = segment.image(buff)
     await page.close().catch((err) => logger.error(err))

--- a/utils/common.js
+++ b/utils/common.js
@@ -358,8 +358,9 @@ export async function renderUrl (e, url, renderCfg = {}) {
       width: 1280,
       height: 720
     })
-    /** 等待markdown-body加载完毕 */
-    await page.waitForSelector(".vuepress-markdown-body")
+    const sleep = ms => new Promise(res => setTimeout(res, ms));
+    /** 等待1秒 */
+    await sleep(1000);
     let buff = base64 = await page.screenshot({ fullPage: true })
     base64 = segment.image(buff)
     await page.close().catch((err) => logger.error(err))

--- a/utils/common.js
+++ b/utils/common.js
@@ -358,7 +358,8 @@ export async function renderUrl (e, url, renderCfg = {}) {
       width: 1280,
       height: 720
     })
-    await page.waitForTimeout(renderCfg.wait || 1000)
+    /** 等待markdown-body加载完毕 */
+    await page.waitForSelector(".vuepress-markdown-body")
     let buff = base64 = await page.screenshot({ fullPage: true })
     base64 = segment.image(buff)
     await page.close().catch((err) => logger.error(err))


### PR DESCRIPTION
修复了新版本puppeteer 的waitForTimeout is not a function的问题 #673 
更改为等待元素` .vuepress-markdown-body`