### PR TITLE
fix: 纯图片触发的伪人对话 跳过查找工具关键词

### DIFF
--- a/model/core.js
+++ b/model/core.js
@@ -591,7 +591,7 @@ class Core {
           await e.reply(msg, true)
         }
       })
-      option.toolMode = (opt.settings.forceTool || Config.geminiForceToolKeywords?.find(k => prompt.includes(k))) ? 'ANY' : 'AUTO'
+      option.toolMode = (opt.settings.forceTool || Config.geminiForceToolKeywords?.find(k => prompt?.includes(k))) ? 'ANY' : 'AUTO'
       return await client.sendMessage(prompt, option)
     } else if (use === 'chatglm4') {
       const client = new ChatGLM4Client({


### PR DESCRIPTION
1|Miao-Yunzai  | [MiaoYz][18:33:56.656][ERRO] [ChatGPT-Plugin 伪人bym][bym] 1|Miao-Yunzai  | [MiaoYz][18:33:56.661][ERRO] TypeError: Cannot read properties of undefined (reading 'includes')
1|Miao-Yunzai  |     at file:///www/fake_mio/bot/Miao-Yunzai/plugins/chatgpt-plugin/model/core.js:594:101
1|Miao-Yunzai  |     at Array.find (<anonymous>)
1|Miao-Yunzai  |     at Core.sendMessage (file:///www/fake_mio/bot/Miao-Yunzai/plugins/chatgpt-plugin/model/core.js:594:84)
1|Miao-Yunzai  |     at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
1|Miao-Yunzai  |     at async bym (file:///www/fake_mio/bot/Miao-Yunzai/plugins/chatgpt-plugin/apps/bym.js:63:17)
1|Miao-Yunzai  |     at async PluginsLoader.deal (file:///www/fake_mio/bot/Miao-Yunzai/lib/plugins/loader.js:275:41)