### PR TITLE
fix: 临时会话会触发伪人模式的bug

### DIFF
--- a/apps/chat.js
+++ b/apps/chat.js
@@ -486,7 +486,7 @@ export class chatgpt extends plugin {
       if (!msg || e.msg?.startsWith('#')) {
         return false
       }
-      if ((e.isGroup || e.group_id) && !(e.atme || e.atBot || (e.at === e.self_id))) {
+      if ((e.isGroup) && !(e.atme || e.atBot || (e.at === e.self_id))) {
         return false
       }
       if (e.user_id == getUin(e)) return false


### PR DESCRIPTION
临时会话下由于e中包含group_id，导致chatgpt方法未阻断执行，还会触发伪人的方法。未加机器人好友的用户在群聊里发起临时会话私聊机器人触发伪人时会往这个群里发消息，包含引用时也会引用到不存在的消息。即便关闭了是否允许私聊机器人的选项也依然会触发。
![234614AE76681D1B0ADED23525229BA1](https://github.com/user-attachments/assets/0fadabf3-d268-43a1-8f6f-7659afb97735)
![PixPin_2025-04-24_02-51-08](https://github.com/user-attachments/assets/72b85635-fc4a-4602-a8df-cc8b1c0f729d)
