### PR TITLE
fix: repair the lowdb storage backend

### DIFF
--- a/apps/chat.js
+++ b/apps/chat.js
@@ -1,7 +1,7 @@
 import Config from '../config/config.js'
 import { Chaite, SendMessageOption } from 'chaite'
 import { getPreset, intoUserMessage, toYunzai } from '../utils/message.js'
-import { YunzaiUserState } from '../models/chaite/storage/lowdb/user_state_storage.js'
+import { YunzaiUserState } from '../models/chaite/user_state.js'
 import { buildGroupContextMessages, getGroupHistory, loadGroupContextImages } from '../utils/group.js'
 import { buildMemoryPrompt } from '../models/memory/prompt.js'
 import { extractTextFromUserMessage, processUserMemory } from '../models/memory/userMemoryManager.js'

--- a/models/chaite/cloud.js
+++ b/models/chaite/cloud.js
@@ -17,6 +17,7 @@ import { LowDBToolsStorage } from './storage/lowdb/tools_storage.js'
 import { LowDBProcessorsStorage } from './storage/lowdb/processors_storage.js'
 import { ChatGPTUserModeSelector } from './user_mode_selector.js'
 import { LowDBUserStateStorage } from './storage/lowdb/user_state_storage.js'
+import { LowDBToolsGroupDTOsStorage } from './storage/lowdb/tool_groups_storage.js'
 import { LowDBHistoryManager } from './storage/lowdb/history_manager.js'
 import { VectraVectorDatabase } from './vector_database.js'
 import path from 'path'
@@ -103,20 +104,24 @@ export async function initChaite () {
       break
     }
     case 'lowdb': {
-      const ChatGPTStorage = (await import('storage/lowdb/storage.js')).default
+      // 相对路径：'storage/lowdb/storage.js' 是裸说明符，既没有对应的包也没有
+      // imports 映射，选到 lowdb 就会 ERR_MODULE_NOT_FOUND
+      const { default: ChatGPTStorage, ChatGPTHistoryStorage } = await import('./storage/lowdb/storage.js')
       await ChatGPTStorage.init()
       channelsStorage = new LowDBChannelStorage(ChatGPTStorage)
       chatPresetsStorage = new LowDBChatPresetsStorage(ChatGPTStorage)
       toolsStorage = new LowDBToolsStorage(ChatGPTStorage)
       processorsStorage = new LowDBProcessorsStorage(ChatGPTStorage)
       userStateStorage = new LowDBUserStateStorage(ChatGPTStorage)
+      toolsGroupStorage = new LowDBToolsGroupDTOsStorage(ChatGPTStorage)
       triggerStorage = new LowDBTriggerStorage(ChatGPTStorage)
       mcpServerStorage = new LowDBMcpServerStorage(ChatGPTStorage)
-      const ChatGPTHistoryStorage = (await import('storage/lowdb/storage.js')).ChatGPTHistoryStorage
       await ChatGPTHistoryStorage.init()
       historyStorage = new LowDBHistoryManager(ChatGPTHistoryStorage)
       break
     }
+    default:
+      throw new Error(`未知的存储实现 chaite.storage=${storage}，可选值：sqlite、lowdb`)
   }
   const channelsManager = await ChannelsManager.init(channelsStorage, new DefaultChannelLoadBalancer())
   const toolsDir = path.resolve('./plugins/chatgpt-plugin', ChatGPTConfig.chaite.toolsDirPath)
@@ -140,11 +145,14 @@ export async function initChaite () {
   const userModeSelector = new ChatGPTUserModeSelector()
   let chaite = Chaite.init(channelsManager, toolsManager, processorsManager, chatPresetManager, toolsGroupManager, triggerManager,
     userModeSelector, userStateStorage, historyStorage, chaiteLogger)
+  // 操作日志是高频写入、保留量按万条计的数据，lowdb 会把整个集合常驻内存并
+  // 整文件重写，不适合做持久化后端。所以 lowdb 下只挂内存版 manager：
+  // 管理面板的日志页面照常可用，只是重启后不保留。
   if (storage === 'sqlite') {
     operationLogStorage = new SQLiteOperationLogStorage(path.join(dataDir, 'operation_logs.db'), ChatGPTConfig.chaite.operationLogLimit)
     await operationLogStorage.initialize()
-    chaite.setOperationLogManager(new OperationLogManager(operationLogStorage))
   }
+  chaite.setOperationLogManager(new OperationLogManager(operationLogStorage))
   chaite.setMcpServerManager(new McpServerManager(mcpServerStorage))
   chaite.setMcpManagementGuard(context => Boolean(context.getEvent()?.isMaster))
   const skillsDir = path.join(dataDir, 'skills')

--- a/models/chaite/storage/lowdb/channel_storage.js
+++ b/models/chaite/storage/lowdb/channel_storage.js
@@ -1,6 +1,10 @@
 import { ChaiteStorage, Channel } from 'chaite'
 
 export class LowDBChannelStorage extends ChaiteStorage {
+  getName () {
+    return 'LowDBChannelStorage'
+  }
+
   /**
    *
    * @param { LowDBStorage } storage

--- a/models/chaite/storage/lowdb/chat_preset_storage.js
+++ b/models/chaite/storage/lowdb/chat_preset_storage.js
@@ -5,6 +5,10 @@ import { invalidatePresetPrefixIndex } from '../../../../utils/presetCache.js'
  * @extends {ChaiteStorage<import('chaite').ChatPreset>}
  */
 export class LowDBChatPresetsStorage extends ChaiteStorage {
+  getName () {
+    return 'LowDBChatPresetsStorage'
+  }
+
   /**
    *
    * @param { LowDBStorage } storage

--- a/models/chaite/storage/lowdb/mcp_server_storage.js
+++ b/models/chaite/storage/lowdb/mcp_server_storage.js
@@ -21,4 +21,5 @@ export class LowDBMcpServerStorage extends ChaiteStorage {
   async listItems () { return await this.collection.findAll() }
   async listItemsByEqFilter (filter) { return (await this.listItems()).filter(item => Object.entries(filter).every(([key, value]) => item[key] === value)) }
   async listItemsByInQuery (query) { return (await this.listItems()).filter(item => query.every(({ field, values }) => values.includes(item[field]))) }
+  async clear () { await this.collection.deleteAll() }
 }

--- a/models/chaite/storage/lowdb/processors_storage.js
+++ b/models/chaite/storage/lowdb/processors_storage.js
@@ -4,6 +4,10 @@ import { ChaiteStorage, ProcessorDTO } from 'chaite'
  * @extends {ChaiteStorage<import('chaite').Processor>}
  */
 export class LowDBProcessorsStorage extends ChaiteStorage {
+  getName () {
+    return 'LowDBProcessorsStorage'
+  }
+
   /**
    *
    * @param { LowDBStorage } storage

--- a/models/chaite/storage/lowdb/tool_groups_storage.js
+++ b/models/chaite/storage/lowdb/tool_groups_storage.js
@@ -4,6 +4,10 @@ import { ChaiteStorage, ToolsGroupDTO } from 'chaite'
  * @extends {ChaiteStorage<import('chaite').ToolsGroupDTO>}
  */
 export class LowDBToolsGroupDTOsStorage extends ChaiteStorage {
+  getName () {
+    return 'LowDBToolsGroupDTOsStorage'
+  }
+
   /**
    *
    * @param { LowDBStorage } storage
@@ -62,6 +66,40 @@ export class LowDBToolsGroupDTOsStorage extends ChaiteStorage {
   async listItems () {
     const list = await this.collection.findAll()
     return list.map(item => new ToolsGroupDTO({}).fromString(JSON.stringify(item)))
+  }
+
+  /**
+   *
+   * @param {Record<string, unknown>} filter
+   * @returns {Promise<import('chaite').ToolsGroupDTO[]>}
+   */
+  async listItemsByEqFilter (filter) {
+    const allList = await this.listItems()
+    return allList.filter(item => {
+      for (const key in filter) {
+        if (item[key] !== filter[key]) {
+          return false
+        }
+      }
+      return true
+    })
+  }
+
+  /**
+   *
+   * @param {Array<{field: string, values: unknown[]}>} query
+   * @returns {Promise<import('chaite').ToolsGroupDTO[]>}
+   */
+  async listItemsByInQuery (query) {
+    const allList = await this.listItems()
+    return allList.filter(item => {
+      for (const { field, values } of query) {
+        if (!values.includes(item[field])) {
+          return false
+        }
+      }
+      return true
+    })
   }
 
   async clear () {

--- a/models/chaite/storage/lowdb/user_state_storage.js
+++ b/models/chaite/storage/lowdb/user_state_storage.js
@@ -1,27 +1,13 @@
 import { ChaiteStorage } from 'chaite'
-import * as crypto from 'node:crypto'
-
-/**
- * 继承UserState
- */
-export class YunzaiUserState {
-  constructor (userId, nickname, card, conversationId = crypto.randomUUID()) {
-    this.userId = userId
-    this.nickname = nickname
-    this.card = card
-    this.conversations = []
-    this.settings = {}
-    this.current = {
-      conversationId,
-      messageId: crypto.randomUUID()
-    }
-  }
-}
 
 /**
  * @extends {ChaiteStorage<import('chaite').UserState>}
  */
 export class LowDBUserStateStorage extends ChaiteStorage {
+  getName () {
+    return 'LowDBUserStateStorage'
+  }
+
   /**
    *
    * @param {LowDBStorage} storage
@@ -76,6 +62,40 @@ export class LowDBUserStateStorage extends ChaiteStorage {
    */
   async listItems () {
     return this.collection.findAll()
+  }
+
+  /**
+   *
+   * @param {Record<string, unknown>} filter
+   * @returns {Promise<import('chaite').UserState[]>}
+   */
+  async listItemsByEqFilter (filter) {
+    const allList = await this.listItems()
+    return allList.filter(item => {
+      for (const key in filter) {
+        if (item[key] !== filter[key]) {
+          return false
+        }
+      }
+      return true
+    })
+  }
+
+  /**
+   *
+   * @param {Array<{field: string, values: unknown[]}>} query
+   * @returns {Promise<import('chaite').UserState[]>}
+   */
+  async listItemsByInQuery (query) {
+    const allList = await this.listItems()
+    return allList.filter(item => {
+      for (const { field, values } of query) {
+        if (!values.includes(item[field])) {
+          return false
+        }
+      }
+      return true
+    })
   }
 
   async clear () {

--- a/models/chaite/user_state.js
+++ b/models/chaite/user_state.js
@@ -1,0 +1,21 @@
+import * as crypto from 'node:crypto'
+
+/**
+ * 默认的 UserState 实现。
+ *
+ * 纯数据类，和具体存储后端无关——之前放在 lowdb 的存储文件里，导致
+ * apps/chat.js 无论配置哪个后端都要 import 一个 lowdb 路径。
+ */
+export class YunzaiUserState {
+  constructor (userId, nickname, card, conversationId = crypto.randomUUID()) {
+    this.userId = userId
+    this.nickname = nickname
+    this.card = card
+    this.conversations = []
+    this.settings = {}
+    this.current = {
+      conversationId,
+      messageId: crypto.randomUUID()
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "sqlite-vec": "^0.1.7-alpha.2"
   },
   "peerDependencies": {
-    "sqlite3": ">=5 <6"
+    "sqlite3": ">=5 <7"
   },
   "pnpm": {}
 }


### PR DESCRIPTION
## 问题

`chaite.storage: 'lowdb'` 从来就跑不起来。`initChaite` 里用裸说明符 import 了 `'storage/lowdb/storage.js'`——既没有同名包，`package.json` 里也没有 `imports` 映射，所以一选 lowdb 就直接 `ERR_MODULE_NOT_FOUND`，一个 storage 都没构造出来。

复现：

```
node --input-type=module -e "import('storage/lowdb/storage.js').catch(e=>console.log(e.code))"
# ERR_MODULE_NOT_FOUND
```

这个崩溃把后面一整串问题都挡住了，所以一并修掉。

## 改动

| 问题 | 说明 |
|---|---|
| 裸说明符 → 相对路径 | 崩溃本身；顺便把两个 export 合并成一次动态 import |
| `toolsGroupStorage` 未赋值 | lowdb 分支漏了，`ToolsGroupManager.init()` 收到 `undefined`——`LowDBToolsGroupDTOsStorage` 一直存在，只是从没被 import |
| 抽象方法缺失 | tool_groups / user_state 缺 `listItemsByEqFilter`、`listItemsByInQuery`；mcp_server 缺 `clear()` |
| 8 个 lowdb storage 里 5 个缺 `getName()` | 日志里显示成 `unknown` |
| 操作日志只在 sqlite 下挂载 | 改为始终挂载 manager，持久化 storage 仍只给 sqlite |
| `YunzaiUserState` 位置不当 | 纯 DTO，和后端无关，移到 `models/chaite/user_state.js` |
| switch 没有 `default` | 未知的 `chaite.storage` 现在会明确报错，而不是一路 `undefined` |
| `sqlite3` peer 范围 | `>=5 <6` → `>=5 <7`，Miao-Yunzai 锁的是 `^6.0.1`，原范围在唯一宿主上就没满足过 |

## 两个需要 review 的判断

**操作日志在 lowdb 下只留内存版**，没有写 `LowDBOperationLogStorage`。操作日志是高频写入、保留量按万条计的数据，而 lowdb 会把整个集合常驻内存并且每次写入重写整个 JSON 文件——拿它做持久化后端是有害的。所以内存版是正确行为，不是偷懒。面板的日志页照常可用，只是重启不保留。

**`LowDBMcpServerStorage` 缺的 `clear()`** 是校验脚本跑出来的，不是读代码看出来的，建议重点看一眼。

## 验证

- 测试 **68 通过 / 1 跳过**。`models/memory/collector.test.js` 有一个先前就存在的失败（`mock.module is not a function`，需要 `--experimental-test-module-mocks`），在 `v3` 上 stash 后复跑同样失败，与本 PR 无关。
- 另写了一次性脚本：实例化全部 8 个 lowdb storage，逐个断言 `ChaiteStorage` 的 7 个方法齐全，并真实跑了一遍写入 → `listItemsByEqFilter` → `listItemsByInQuery` → `removeItem`。缺失的 `clear()` 就是这么发现的。脚本用完已删。

## 已知未覆盖

**没有在真实 Yunzai 运行时下以 `chaite.storage: 'lowdb'` 完整启动过**——那需要完整的 QQ 登录环境。模块解析和接口齐全性已经修好并验证，但合并前值得跑一次真实冒烟测试。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
