### PR TITLE
fix(memory): 向量按群分区，rowid 改用 Number 绑定

### DIFF
--- a/models/memory/database.js
+++ b/models/memory/database.js
@@ -4,6 +4,8 @@ import fs from 'fs'
 import path from 'path'
 import ChatGPTConfig from '../../config/config.js'
 
+const VECTOR_TABLE = 'vec_group_facts'
+const VECTOR_MIGRATION_TMP = 'vec_group_facts_migration_tmp'
 const META_VECTOR_DIM_KEY = 'group_vec_dimension'
 const META_VECTOR_MODEL_KEY = 'group_vec_model'
 const META_GROUP_TOKENIZER_KEY = 'group_memory_tokenizer'
@@ -792,7 +794,67 @@ async function createVectorTable (db, dimension) {
   if (optionalDependencyState.vectorError) {
     throw optionalDependencyState.vectorError
   }
-  await db.exec(`CREATE VIRTUAL TABLE vec_group_facts USING vec0(embedding float[${dimension}])`)
+  // group_id 作为 PARTITION KEY：KNN 只在本群的分区里找。
+  //
+  // 旧表没有这一列，只能先全库取 top-k 再 JOIN 过滤群号——k=5 的情况下，
+  // 一个只占全部向量 0.5% 的小群期望能留下 0.02 条结果，等于向量检索对它
+  // 完全失效，而且会静默退化成文本检索，看不出来。
+  await db.exec(
+    `CREATE VIRTUAL TABLE ${VECTOR_TABLE} USING vec0(group_id TEXT PARTITION KEY, embedding float[${dimension}])`
+  )
+}
+
+/**
+ * 老库的向量表没有 group_id 分区列，这里原地改造。
+ *
+ * 向量本身不用重新生成：vec0 可以把 embedding 原样读回来，rowid 就是
+ * group_facts.id，群号 JOIN 一下就有。整个搬运在 SQL 里完成，不把几百 MB
+ * 的向量读进 JS。
+ *
+ * @returns {Promise<boolean>} 是否执行了迁移
+ */
+async function migrateVectorTableToPartitioned (db, dimension) {
+  const existing = await db.prepare(`
+    SELECT sql FROM sqlite_master WHERE type = 'table' AND name = ?
+  `).get(VECTOR_TABLE)
+  if (!existing?.sql) return false
+  if (/partition\s+key/i.test(existing.sql)) return false
+
+  const before = await db.prepare(`SELECT COUNT(*) AS n FROM ${VECTOR_TABLE}`).get().catch(() => ({ n: 0 }))
+  const count = Number(before?.n || 0)
+  // 一次性操作，但在大库上不快：3072 维、3 万条实测约 90 秒。这期间记忆检索
+  // 会等着，所以把预计耗时打出来，免得看起来像卡死。
+  logger?.info?.(
+    `[Memory] 向量表缺少 group_id 分区列，开始原地迁移 ${count} 条向量` +
+    `（不需要重新生成向量，预计 ${Math.max(1, Math.round(count / 350))} 秒左右）`
+  )
+  const startedAt = Date.now()
+  await db.exec(`DROP TABLE IF EXISTS ${VECTOR_MIGRATION_TMP}`)
+  await db.exec(`CREATE TABLE ${VECTOR_MIGRATION_TMP} (rowid INTEGER PRIMARY KEY, group_id TEXT, embedding BLOB)`)
+
+  // 只搬还能对上 fact 的向量；对不上的是孤儿，留着也没用
+  const staged = await db.prepare(`
+    INSERT INTO ${VECTOR_MIGRATION_TMP}(rowid, group_id, embedding)
+    SELECT v.rowid, g.group_id, v.embedding
+    FROM ${VECTOR_TABLE} v
+    JOIN group_facts g ON g.id = v.rowid
+  `).run()
+
+  await db.exec(`DROP TABLE ${VECTOR_TABLE}`)
+  await createVectorTable(db, dimension)
+  const restored = await db.prepare(`
+    INSERT INTO ${VECTOR_TABLE}(rowid, group_id, embedding)
+    SELECT rowid, group_id, embedding FROM ${VECTOR_MIGRATION_TMP}
+  `).run()
+  await db.exec(`DROP TABLE ${VECTOR_MIGRATION_TMP}`)
+
+  const orphaned = count - Number(staged?.changes || 0)
+  logger?.info?.(
+    `[Memory] 向量表迁移完成：搬运 ${restored?.changes ?? 0} 条，` +
+    `耗时 ${((Date.now() - startedAt) / 1000).toFixed(1)}s` +
+    (orphaned > 0 ? `，丢弃 ${orphaned} 条对不上 fact 的孤儿向量` : '')
+  )
+  return true
 }
 
 async function ensureVectorTable (db) {
@@ -811,8 +873,8 @@ async function ensureVectorTable (db) {
   const currentModel = ChatGPTConfig.llm?.embeddingModel || ''
   const tableExists = Boolean(await db.prepare(`
     SELECT name FROM sqlite_master
-    WHERE type = 'table' AND name = 'vec_group_facts'
-  `).get())
+    WHERE type = 'table' AND name = ?
+  `).get(VECTOR_TABLE))
 
   const parseDimension = value => {
     if (!value && value !== 0) return 0
@@ -831,7 +893,7 @@ async function ensureVectorTable (db) {
 
   if (needsTableReset && tableExists) {
     try {
-      await db.exec('DROP TABLE IF EXISTS vec_group_facts')
+      await db.exec(`DROP TABLE IF EXISTS ${VECTOR_TABLE}`)
       tablePresent = false
       dimension = 0
     } catch (err) {
@@ -860,6 +922,12 @@ async function ensureVectorTable (db) {
   }
 
   if (tablePresent && storedDimension > 0) {
+    // 老库的向量表没有分区列，在这里补上（失败不该让记忆功能整个起不来）
+    try {
+      await migrateVectorTableToPartitioned(db, storedDimension)
+    } catch (err) {
+      logger?.error?.('[Memory] 向量表分区迁移失败，向量检索将继续使用旧结构:', err)
+    }
     cachedVectorDimension = storedDimension
     cachedVectorModel = storedModel || currentModel
     return cachedVectorDimension
@@ -878,7 +946,7 @@ export async function resetVectorTableDimension (dimension) {
   }
   const db = await getMemoryDatabase()
   try {
-    await db.exec('DROP TABLE IF EXISTS vec_group_facts')
+    await db.exec(`DROP TABLE IF EXISTS ${VECTOR_TABLE}`)
   } catch (err) {
     logger?.warn?.('[Memory] failed to drop vec_group_facts:', err)
   }

--- a/models/memory/groupMemoryStore.js
+++ b/models/memory/groupMemoryStore.js
@@ -86,8 +86,11 @@ export class GroupMemoryStore {
 
   prepareVectorStatements () {
     try {
-      this.deleteVecStmt = this.db.prepare('DELETE FROM vec_group_facts WHERE rowid = ?')
-      this.insertVecStmt = this.db.prepare('INSERT INTO vec_group_facts(rowid, embedding) VALUES (?, ?)')
+      // rowid 必须用 Number 传，不能用 BigInt：node-sqlite3 不支持绑定 BigInt，
+      // 会当成 NULL，于是 INSERT 拿到一个自动分配的 rowid（和 fact id 对不上），
+      // DELETE 则一条都匹配不到（changes=0）。两者都不报错，所以一直没被发现。
+      this.deleteVecStmt = this.db.prepare('DELETE FROM vec_group_facts WHERE rowid = ? AND group_id = ?')
+      this.insertVecStmt = this.db.prepare('INSERT INTO vec_group_facts(rowid, group_id, embedding) VALUES (?, ?, ?)')
     } catch (err) {
       this.deleteVecStmt = null
       this.insertVecStmt = null
@@ -263,10 +266,9 @@ export class GroupMemoryStore {
             } else {
               embeddingArray = Float32Array.from(vector)
             }
-            const rowId = BigInt(factId)
-            logger.debug(`[Memory] upserting vector for fact ${factId}, rowIdType=${typeof rowId}`)
-            await this.deleteVecStmt.run(rowId)
-            await this.insertVecStmt.run(rowId, embeddingArray)
+            const rowId = Number(factId)
+            await this.deleteVecStmt.run(rowId, normGroupId)
+            await this.insertVecStmt.run(rowId, normGroupId, embeddingArray)
           } catch (error) {
             logger.error(`Failed to upsert vector for fact ${factId}:`, error)
           }
@@ -298,7 +300,7 @@ export class GroupMemoryStore {
     }
     await this.db.prepare('DELETE FROM group_facts WHERE id = ?').run(factId)
     try {
-      await this.deleteVecStmt.run(BigInt(factId))
+      await this.deleteVecStmt.run(Number(factId), normGroupId)
     } catch (err) {
       logger?.warn?.(`[Memory] failed to delete vector for fact ${factId}:`, err)
     }
@@ -348,13 +350,16 @@ export class GroupMemoryStore {
           return []
         }
       }
+      // 按分区过滤再取 top-k。旧写法是先全库 top-k、再 JOIN 过滤群号，
+      // 小群基本什么都留不下（k=5 时期望不到 0.1 条），而且会静默退化成
+      // 文本检索，表面上看不出问题。
       const rows = await this.db.prepare(`
         SELECT gf.*, vec_group_facts.distance AS distance
         FROM vec_group_facts
         JOIN group_facts gf ON gf.id = vec_group_facts.rowid
-        WHERE gf.group_id = ?
+        WHERE vec_group_facts.group_id = ?
           AND vec_group_facts.embedding MATCH ?
-          AND vec_group_facts.k = ${limit}
+          AND vec_group_facts.k = ${Math.max(1, Math.trunc(Number(limit)) || 1)}
         ORDER BY distance ASC
       `).all(groupId, embeddingVector)
       const threshold = this.vectorDistanceThreshold

--- a/models/memory/vectorPartition.test.js
+++ b/models/memory/vectorPartition.test.js
@@ -1,0 +1,196 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { createRequire } from 'node:module'
+import sqlite3 from 'sqlite3'
+
+globalThis.logger ??= { debug () {}, info () {}, warn () {}, error () {}, mark () {} }
+
+const require = createRequire(import.meta.url)
+
+/**
+ * 向量表分区化的回归测试。
+ *
+ * 这里刻意不经过 database.js / groupMemoryStore.js，而是直接对着 sqlite-vec
+ * 验证两件事——它们是分区改造能成立的全部前提，也是改造前实际踩到的两个坑：
+ *
+ *  1. 不带分区的 KNN 必须先全库取 top-k 再过滤群号，小群会被大群挤掉；
+ *     带 PARTITION KEY 之后只在本群分区里找，结果完全正确。
+ *  2. rowid 只能用 Number 绑定。BigInt 在 node-sqlite3 里会被当成 NULL，
+ *     INSERT 拿到自动分配的 rowid、DELETE 一条都删不掉，而且都不报错。
+ *
+ * 没装 sqlite-vec 时整组跳过——它是可选依赖，小机器上本来就可能没有。
+ */
+
+let sqliteVec = null
+try {
+  sqliteVec = require('sqlite-vec')
+} catch {
+  sqliteVec = null
+}
+
+const DIM = 8
+
+function tempDb () {
+  return path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'vecpart-')), 'memory.db')
+}
+
+async function openDb () {
+  const db = new sqlite3.Database(tempDb())
+  await new Promise(resolve => db.serialize(resolve))
+  sqliteVec.load(db)
+  return {
+    exec: sql => new Promise((res, rej) => db.exec(sql, e => e ? rej(e) : res())),
+    run: (sql, p = []) => new Promise((res, rej) => db.run(sql, p, function (e) { e ? rej(e) : res(this) })),
+    all: (sql, p = []) => new Promise((res, rej) => db.all(sql, p, (e, r) => e ? rej(e) : res(r))),
+    close: () => new Promise(res => db.close(res))
+  }
+}
+
+/** 单位向量，便于构造可预测的距离 */
+function vec (seed) {
+  const a = new Float32Array(DIM)
+  a[0] = Math.cos(seed)
+  a[1] = Math.sin(seed)
+  return Buffer.from(a.buffer)
+}
+
+const suite = sqliteVec ? test : test.skip
+
+suite('不分区时，小群会被大群挤出 top-k', async () => {
+  const db = await openDb()
+  await db.exec('CREATE TABLE group_facts (id INTEGER PRIMARY KEY, group_id TEXT, fact TEXT)')
+  await db.exec(`CREATE VIRTUAL TABLE vec_old USING vec0(embedding float[${DIM}])`)
+
+  // 模拟生产分布：大群的向量都挤在查询附近，小群的离得远。
+  // 这正是真实情况——某个群占了 67% 的向量，另一个只占 0.5%。
+  let id = 1
+  for (let i = 0; i < 200; i++, id++) {
+    await db.run('INSERT INTO group_facts VALUES (?,?,?)', [id, 'big', 'b' + i])
+    await db.run('INSERT INTO vec_old(rowid, embedding) VALUES (?,?)', [id, vec(0.001 * i)])
+  }
+  const smallIds = []
+  for (let i = 0; i < 3; i++, id++) {
+    await db.run('INSERT INTO group_facts VALUES (?,?,?)', [id, 'small', 's' + i])
+    await db.run('INSERT INTO vec_old(rowid, embedding) VALUES (?,?)', [id, vec(2 + 0.1 * i)])
+    smallIds.push(id)
+  }
+
+  // 旧查询：全库 top-5，再 JOIN 过滤群号
+  const rows = await db.all(`
+    SELECT gf.id FROM vec_old
+    JOIN group_facts gf ON gf.id = vec_old.rowid
+    WHERE gf.group_id = 'small' AND vec_old.embedding MATCH ? AND vec_old.k = 5
+    ORDER BY distance
+  `, [vec(0)])
+  // 全库 top-5 全被大群占满，过滤群号之后一条不剩
+  assert.equal(rows.length, 0,
+    `旧写法下小群应当召回不到任何向量，实际返回 ${rows.length} 条`)
+  await db.close()
+})
+
+suite('分区之后，小群能完整召回自己的向量', async () => {
+  const db = await openDb()
+  await db.exec('CREATE TABLE group_facts (id INTEGER PRIMARY KEY, group_id TEXT, fact TEXT)')
+  await db.exec(`CREATE VIRTUAL TABLE vec_new USING vec0(group_id TEXT PARTITION KEY, embedding float[${DIM}])`)
+
+  let id = 1
+  for (let i = 0; i < 200; i++, id++) {
+    await db.run('INSERT INTO group_facts VALUES (?,?,?)', [id, 'big', 'b' + i])
+    await db.run('INSERT INTO vec_new(rowid, group_id, embedding) VALUES (?,?,?)', [id, 'big', vec(0.001 * i)])
+  }
+  const smallIds = []
+  for (let i = 0; i < 3; i++, id++) {
+    await db.run('INSERT INTO group_facts VALUES (?,?,?)', [id, 'small', 's' + i])
+    await db.run('INSERT INTO vec_new(rowid, group_id, embedding) VALUES (?,?,?)', [id, 'small', vec(2 + 0.1 * i)])
+    smallIds.push(id)
+  }
+
+  const rows = await db.all(`
+    SELECT gf.id FROM vec_new
+    JOIN group_facts gf ON gf.id = vec_new.rowid
+    WHERE vec_new.group_id = ? AND vec_new.embedding MATCH ? AND vec_new.k = 5
+    ORDER BY distance
+  `, ['small', vec(0)])
+
+  assert.equal(rows.length, smallIds.length, '小群的三条向量都应该被召回')
+  assert.deepEqual(rows.map(r => r.id).sort((a, b) => a - b), smallIds)
+  await db.close()
+})
+
+suite('rowid 用 BigInt 绑定会静默出错，用 Number 才正确', async () => {
+  const db = await openDb()
+  await db.exec(`CREATE VIRTUAL TABLE v USING vec0(group_id TEXT PARTITION KEY, embedding float[${DIM}])`)
+
+  // BigInt：插入拿到的不是指定的 rowid，删除也匹配不到，两者都不抛错
+  await db.run('INSERT INTO v(rowid, group_id, embedding) VALUES (?,?,?)', [BigInt(12345), 'g1', vec(0)])
+  const afterBigInt = await db.all('SELECT rowid FROM v')
+  assert.notEqual(afterBigInt[0].rowid, 12345, 'BigInt 绑定后 rowid 不应等于指定值（这正是 bug）')
+  const del = await db.run('DELETE FROM v WHERE rowid = ? AND group_id = ?', [BigInt(12345), 'g1'])
+  assert.equal(del.changes, 0, 'BigInt 删除应当一条都匹配不到')
+
+  // Number：两者都正确
+  await db.exec('DELETE FROM v')
+  await db.run('INSERT INTO v(rowid, group_id, embedding) VALUES (?,?,?)', [12345, 'g1', vec(0)])
+  const afterNumber = await db.all('SELECT rowid FROM v')
+  assert.equal(afterNumber[0].rowid, 12345)
+  const del2 = await db.run('DELETE FROM v WHERE rowid = ? AND group_id = ?', [12345, 'g1'])
+  assert.equal(del2.changes, 1)
+  await db.close()
+})
+
+suite('迁移：老表的向量能原样搬进分区表，不需要重新生成', async () => {
+  const db = await openDb()
+  await db.exec('CREATE TABLE group_facts (id INTEGER PRIMARY KEY, group_id TEXT, fact TEXT)')
+  await db.exec(`CREATE VIRTUAL TABLE vec_group_facts USING vec0(embedding float[${DIM}])`)
+
+  const planted = [[10, 'g1'], [20, 'g2'], [30, 'g1']]
+  for (const [id, g] of planted) {
+    await db.run('INSERT INTO group_facts VALUES (?,?,?)', [id, g, 'f' + id])
+    await db.run('INSERT INTO vec_group_facts(rowid, embedding) VALUES (?,?)', [id, vec(id / 100)])
+  }
+  // 再放一条对不上 fact 的孤儿向量，迁移时应当被丢掉
+  await db.run('INSERT INTO vec_group_facts(rowid, embedding) VALUES (?,?)', [999, vec(9)])
+
+  // 复刻 database.js 里的迁移步骤
+  await db.exec('CREATE TABLE tmp (rowid INTEGER PRIMARY KEY, group_id TEXT, embedding BLOB)')
+  const staged = await db.run(`
+    INSERT INTO tmp(rowid, group_id, embedding)
+    SELECT v.rowid, g.group_id, v.embedding
+    FROM vec_group_facts v JOIN group_facts g ON g.id = v.rowid
+  `)
+  assert.equal(staged.changes, planted.length, '只搬能对上 fact 的向量')
+
+  await db.exec('DROP TABLE vec_group_facts')
+  await db.exec(`CREATE VIRTUAL TABLE vec_group_facts USING vec0(group_id TEXT PARTITION KEY, embedding float[${DIM}])`)
+  const restored = await db.run(`
+    INSERT INTO vec_group_facts(rowid, group_id, embedding)
+    SELECT rowid, group_id, embedding FROM tmp
+  `)
+  assert.equal(restored.changes, planted.length)
+  await db.exec('DROP TABLE tmp')
+
+  // 分区查询要能命中，且 rowid 与 fact id 仍然对应
+  const hits = await db.all(`
+    SELECT rowid, distance FROM vec_group_facts
+    WHERE group_id = ? AND embedding MATCH ? AND k = 5 ORDER BY distance
+  `, ['g1', vec(0.1)])
+  assert.deepEqual(hits.map(h => h.rowid).sort((a, b) => a - b), [10, 30])
+  assert.equal(hits[0].distance, 0, '搬过来的向量应当与原值逐位一致')
+  await db.close()
+})
+
+suite('迁移检测：只认没有 PARTITION KEY 的老表', async () => {
+  const db = await openDb()
+  await db.exec(`CREATE VIRTUAL TABLE old_shape USING vec0(embedding float[${DIM}])`)
+  await db.exec(`CREATE VIRTUAL TABLE new_shape USING vec0(group_id TEXT PARTITION KEY, embedding float[${DIM}])`)
+
+  const sqlOf = async name => (await db.all(
+    'SELECT sql FROM sqlite_master WHERE type = ? AND name = ?', ['table', name]))[0]?.sql || ''
+
+  assert.ok(!/partition\s+key/i.test(await sqlOf('old_shape')), '老表不该被判定为已分区')
+  assert.ok(/partition\s+key/i.test(await sqlOf('new_shape')), '新表应当被判定为已分区')
+  await db.close()
+})


### PR DESCRIPTION
> 从 #840 里拆出来的。这部分**不依赖 chaite 新版本**，可以先单独合并；#840 要等 chaite 发版。

## 两个静默的 bug，都在削弱向量召回

### 1. 向量表没有群维度，只能先全库取 top-k 再过滤

旧查询是这样的：

```sql
FROM vec_group_facts
JOIN group_facts gf ON gf.id = vec_group_facts.rowid
WHERE gf.group_id = ?
  AND vec_group_facts.embedding MATCH ?
  AND vec_group_facts.k = 5
```

`vec_group_facts` 里只有 `(rowid, embedding)`，没有群号。所以 sqlite-vec 返回的是**全库最近的 5 条**，之后才 JOIN 过滤群号。

线上实测这台机器：40,515 条 fact 分布在 5 个群，`27212 / 9044 / 3510 / 561 / 188`。k=5 的情况下，占比 0.46% 的那个群期望能留下 **0.02 条**结果。**5 个群里有 3 个的向量检索实际上是失效的。**

而且看不出来：`queryRelevantFacts` 在向量结果不足时会补文本检索，所以表面上一切正常。

sqlite-vec 支持 `PARTITION KEY`，改成：

```sql
CREATE VIRTUAL TABLE vec_group_facts USING vec0(
  group_id TEXT PARTITION KEY,
  embedding float[3072]
)
```

之后 KNN 只在本群分区里找。

### 2. rowid 用 BigInt 绑定，插入和删除都静默失效

```js
const rowId = BigInt(factId)
await this.deleteVecStmt.run(rowId)
await this.insertVecStmt.run(rowId, embeddingArray)
```

node-sqlite3 不支持绑定 BigInt——它会被当成 NULL。于是：

* `INSERT` 拿到的是**自动分配的 rowid**，和 `group_facts.id` 对不上
* `DELETE` 一条都匹配不到（`changes = 0`）
* 两者都不抛错

在部署机自己的运行时上直接验证过（node 20.18.1 + sqlite3 5.1.6），node 22 + sqlite3 6.0.1 同样如此。现在两处都用 `Number`，删除也带上分区键（分区表要求）。

这也解释了线上数据的一个现象：**最新创建的 8 条 fact 一条向量都没有**，全部 40,560 条里有 9,803 条缺向量。

## 迁移：不需要重新生成向量

首次用到记忆时自动原地迁移。向量不用重算——`vec0` 能把 embedding 原样读回，`rowid` 本来就是 `group_facts.id`，群号 JOIN 一下就有。整个搬运在 SQL 里用一张暂存表完成，不把几百 MB 向量读进 JS。对不上 fact 的孤儿向量会被丢掉。

拿线上 437 MiB 的 `memory.db` 副本实测（原库未改动）：

| | 结果 |
|---|---|
| 迁移 | 30,760 条 3072 维向量，**91 秒** |
| 丢弃孤儿 | 3 条 |
| 迁移后召回 | **每个群都能拿满 k=5** |
| 查询耗时 | 179ms（27k 分区）→ 7ms（188 条） |

91 秒是一次性的，但不算快，所以开始前会把条数和预计耗时打到日志里，避免看起来像卡死。

## 顺便说明：不需要 FAISS 或 pgvector

评估过了，两个都不需要：

* `vec0` 接受 **3072 维**，而 pgvector 的 HNSW / ivfflat **索引上限是 2000 维**，实测直接报错。用 pgvector 就得把 embedding 降到 1536 重算一遍。
* 最大分区上做精确检索 179ms，不到一次 embedding 往返的时间，而每轮对话要打两次 embedding。向量检索不是瓶颈。
* FAISS/hnswlib 要引入原生模块、单独维护索引文件与 SQL 的一致性、索引常驻内存（f32 下约 378 MB）。小机器上得不偿失，而且会让两种硬件档次走不同代码路径。

真到最大的群超过约 20 万条 fact 时再考虑 ANN，现在远没到。

## 测试

新增 5 个（`models/memory/vectorPartition.test.js`），全部通过；原有 44 个无回归。

其中第一个用例直接固定住 bug 的形状：大群向量都挤在查询附近、小群离得远时，**旧写法对小群返回 0 条**，分区之后返回全部 3 条。第三个用例固定住 BigInt 的行为，避免以后又改回去。

sqlite-vec 是可选依赖，没装时整组跳过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
